### PR TITLE
Fixes for running with docker profile

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -48,6 +48,7 @@ profiles {
   docker {
     docker.enabled = true
     docker.runOptions = '-u root'
+    docker.fixOwnership = true
   }
   singularity {
     singularity.enabled = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,7 +35,7 @@ params {
   chunk = ''
 }
 
-process.container = 'docker://quay.io/h3abionet_org/imputation_tools' // Container slug. Stable releases should specify release tag!
+process.container = 'quay.io/h3abionet_org/imputation_tools' // Container slug. Stable releases should specify release tag!
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
@@ -45,7 +45,10 @@ profiles {
   test { includeConfig 'conf/test.config' }
   debug { process.beforeScript = 'echo $HOSTNAME' }
   conda { process.conda = "$baseDir/environment.yml" }
-  docker { docker.enabled = true }
+  docker {
+    docker.enabled = true
+    docker.runOptions = '-u root'
+  }
   singularity {
     singularity.enabled = true
     singularity.autoMounts = true


### PR DESCRIPTION
Docker does not like the `docker://` pragma before container paths.
Removing it does not seem to affect running under singularity.

Also the container does not have adequate permissions under docker,
so running as root in the docker container fixes this.